### PR TITLE
Add the spawner involved with the SpawnerPlaceEvent to the event API

### DIFF
--- a/src/main/java/com/github/mlefeb01/spawners/events/SpawnerPlaceEvent.java
+++ b/src/main/java/com/github/mlefeb01/spawners/events/SpawnerPlaceEvent.java
@@ -1,5 +1,6 @@
 package com.github.mlefeb01.spawners.events;
 
+import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -10,11 +11,13 @@ public class SpawnerPlaceEvent extends PlayerEvent implements Cancellable {
     private EntityType spawnerType;
     private static final HandlerList HANDLERS = new HandlerList();
     private boolean isCancelled;
+    private final Block spawner;
 
-    public SpawnerPlaceEvent(Player player, EntityType spawnerType) {
+    public SpawnerPlaceEvent(Player player, EntityType spawnerType, Block spawner) {
         super(player);
         this.isCancelled = false;
         this.spawnerType = spawnerType;
+        this.spawner = spawner;
     }
 
     public boolean isCancelled() {
@@ -39,6 +42,10 @@ public class SpawnerPlaceEvent extends PlayerEvent implements Cancellable {
 
     public void setSpawnerType(EntityType spawnerType) {
         this.spawnerType = spawnerType;
+    }
+
+    public Block getSpawner() {
+        return this.spawner;
     }
 
 }

--- a/src/main/java/com/github/mlefeb01/spawners/handlers/SpawnerHandler.java
+++ b/src/main/java/com/github/mlefeb01/spawners/handlers/SpawnerHandler.java
@@ -309,7 +309,7 @@ public class SpawnerHandler implements Listener, CommandExecutor {
 
         // Create the SpawnerPlaceEvent and call it. Make sure the event hasnt been cancelled before proceeding
         final EntityType tempType = EntityType.valueOf(nbtItem.hasKey(NBT_SPAWNER_TYPE) ? nbtItem.getString(NBT_SPAWNER_TYPE) : "PIG");
-        final SpawnerPlaceEvent spawnerPlaceEvent = new SpawnerPlaceEvent(player, tempType);
+        final SpawnerPlaceEvent spawnerPlaceEvent = new SpawnerPlaceEvent(player, tempType, event.getBlock());
         Bukkit.getPluginManager().callEvent(spawnerPlaceEvent);
         if (spawnerPlaceEvent.isCancelled()) {
             return;


### PR DESCRIPTION
This allows for other plugins to access the block of the spawner similar to how it's already accessible through SpawnerMineEvent.