### PR TITLE
Cancel bukkit events & update item-nbt-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compileOnly 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
-    compile 'de.tr7zw:item-nbt-api-plugin:2.3.0'
+    compile 'de.tr7zw:item-nbt-api-plugin:2.3.1'
 }
 
 shadowJar {

--- a/src/main/java/com/github/mlefeb01/spawners/handlers/SpawnerHandler.java
+++ b/src/main/java/com/github/mlefeb01/spawners/handlers/SpawnerHandler.java
@@ -210,6 +210,7 @@ public class SpawnerHandler implements Listener, CommandExecutor {
                 (config.getBoolean("spawners.tax.enabled")) ? spawnerTax.getOrDefault(tempType, 0.0) : 0.0, Math.random() * 100, block);
         Bukkit.getPluginManager().callEvent(spawnerMineEvent);
         if (spawnerMineEvent.isCancelled()) {
+            event.setCancelled(true);
             return;
         }
 
@@ -312,6 +313,7 @@ public class SpawnerHandler implements Listener, CommandExecutor {
         final SpawnerPlaceEvent spawnerPlaceEvent = new SpawnerPlaceEvent(player, tempType, event.getBlock());
         Bukkit.getPluginManager().callEvent(spawnerPlaceEvent);
         if (spawnerPlaceEvent.isCancelled()) {
+            event.setCancelled(true);
             return;
         }
 


### PR DESCRIPTION
Apparently not having the latest item-nbt-api version gives an annoying error in console to update all the time, so lets just do that to suppress the issue.

Also, noticed that the bukkit events don't actually get cancelled so you need to listen to 4 events, if we just cancel the bukkit events we only have to listen to 2. Found this to be pretty useful for my use cases as if you cancel the SpawnerPlugin place event it will still put a spawner there unless you listen & cancel to BlockPlaceEvent aswell. Should theoretically be the same issue with breaking spawners.